### PR TITLE
chore(node): remove node version engine from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "homepage": "https://github.com/Interencheres/cpm-validator#readme",
   "engines": {
-    "node": "4.2.x"
+    "node": ">=4.2"
   },
   "dependencies": {
     "is-my-json-valid": "^2.13.1",


### PR DESCRIPTION
Specifying engine in package is way too strict